### PR TITLE
Change how platform is mocked when testing path functions

### DIFF
--- a/test/functional/multi-database/multi-database-basic-functionality/multi-database-basic-functionality.ts
+++ b/test/functional/multi-database/multi-database-basic-functionality/multi-database-basic-functionality.ts
@@ -25,13 +25,13 @@ describe("multi-database > basic-functionality", () => {
             it(`[${platform}] produces deterministic, unique, and valid table names for relative paths; leaves absolute paths unchanged`, () => {
                 const testMap = [
                     ["FILENAME.db", "filename.db"],
-                    ["..\\FILENAME.db", platform === 'win32' ? "../filename.db" : "..\\FILENAME.db"],
-                    [".\\FILENAME.db", platform === 'win32' ? "./filename.db" : ".\\FILENAME.db"],
+                    ["..\\FILENAME.db", platform === 'win32' ? "../filename.db" : "..\\filename.db"],
+                    [".\\FILENAME.db", platform === 'win32' ? "./filename.db" : ".\\filename.db"],
                     [
                         "..\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\FILENAME.db",
                         platform === 'win32'
                             ? "../longpathdir/longpathdir/longpathdir/longpathdir/longpathdir/longpathdir/longpathdir/filename.db"
-                            : "..\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\FILENAME.db",
+                            : "..\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\filename.db",
                     ],
                     ["C:\\dirFILENAME.db", "C:\\dirFILENAME.db"],
                     ["/dir/filename.db", "/dir/filename.db"],

--- a/test/functional/multi-database/multi-database-basic-functionality/multi-database-basic-functionality.ts
+++ b/test/functional/multi-database/multi-database-basic-functionality/multi-database-basic-functionality.ts
@@ -25,11 +25,13 @@ describe("multi-database > basic-functionality", () => {
             it(`[${platform}] produces deterministic, unique, and valid table names for relative paths; leaves absolute paths unchanged`, () => {
                 const testMap = [
                     ["FILENAME.db", "filename.db"],
-                    ["..\\FILENAME.db", "../filename.db"],
-                    [".\\FILENAME.db", "./filename.db"],
+                    ["..\\FILENAME.db", platform === 'win32' ? "../filename.db" : "..\\FILENAME.db"],
+                    [".\\FILENAME.db", platform === 'win32' ? "./filename.db" : ".\\FILENAME.db"],
                     [
                         "..\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\FILENAME.db",
-                        "../longpathdir/longpathdir/longpathdir/longpathdir/longpathdir/longpathdir/longpathdir/filename.db",
+                        platform === 'win32'
+                            ? "../longpathdir/longpathdir/longpathdir/longpathdir/longpathdir/longpathdir/longpathdir/filename.db"
+                            : "..\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\FILENAME.db",
                     ],
                     ["C:\\dirFILENAME.db", "C:\\dirFILENAME.db"],
                     ["/dir/filename.db", "/dir/filename.db"],

--- a/test/unit/path-utils.ts
+++ b/test/unit/path-utils.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, toPortablePath } from "../../src/util/PathUtils"
 import { expect } from "chai"
+import { withPlatform } from "../utils/test-utils"
 
 describe(`path-utils`, () => {
     describe("isAbsolute", () => {
@@ -25,92 +26,150 @@ describe(`path-utils`, () => {
     })
 
     describe("toPortablePath", () => {
-        describe(`toPortablePath`, () => {
-            if (process.platform !== `win32`) {
-                it(`should change paths on non-Windows platform`, () => {
-                    const inputPath = `C:\\Users\\user\\proj`
-                    const outputPath = inputPath
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
-            } else {
-                it(`shouldn't change absolute posix paths when producing portable path`, () => {
-                    const inputPath = `/home/user/proj`
-                    const outputPath = inputPath
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
+        for (const platform of [`darwin`, `win32`]) {
+            describe(`[${platform}] toPortablePath`, () => {
+                if (platform !== `win32`) {
+                    it(`shouldn't change paths on non-Windows platform`, () => {
+                        const inputPath = `C:\\Users\\user\\proj`
+                        const outputPath = inputPath
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
+                } else {
+                    it(`shouldn't change absolute posix paths when producing portable path`, () => {
+                        const inputPath = `/home/user/proj`
+                        const outputPath = inputPath
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
 
-                it(`shouldn't change absolute paths that are already portable`, () => {
-                    const inputPath = `/c:/Users/user/proj`
-                    const outputPath = `/c:/Users/user/proj`
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
+                    it(`shouldn't change absolute paths that are already portable`, () => {
+                        const inputPath = `/c:/Users/user/proj`
+                        const outputPath = `/c:/Users/user/proj`
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
 
-                it(`should normalize the slashes in relative Windows paths`, () => {
-                    const inputPath = `..\\Users\\user/proj`
-                    const outputPath = `../Users/user/proj`
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
+                    it(`should normalize the slashes in relative Windows paths`, () => {
+                        const inputPath = `..\\Users\\user/proj`
+                        const outputPath = `../Users/user/proj`
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
 
-                it(`should transform Windows paths into their posix counterparts (uppercase drive)`, () => {
-                    const inputPath = `C:\\Users\\user\\proj`
-                    const outputPath = `/C:/Users/user/proj`
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
+                    it(`should transform Windows paths into their posix counterparts (uppercase drive)`, () => {
+                        const inputPath = `C:\\Users\\user\\proj`
+                        const outputPath = `/C:/Users/user/proj`
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
 
-                it(`should transform Windows paths into their posix counterparts (lowercase drive)`, () => {
-                    const inputPath = `c:\\Users\\user\\proj`
-                    const outputPath = `/c:/Users/user/proj`
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
+                    it(`should transform Windows paths into their posix counterparts (lowercase drive)`, () => {
+                        const inputPath = `c:\\Users\\user\\proj`
+                        const outputPath = `/c:/Users/user/proj`
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
 
-                it(`should transform Windows paths into their posix counterparts (forward slashes)`, () => {
-                    const inputPath = `C:/Users/user/proj`
-                    const outputPath = `/C:/Users/user/proj`
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
+                    it(`should transform Windows paths into their posix counterparts (forward slashes)`, () => {
+                        const inputPath = `C:/Users/user/proj`
+                        const outputPath = `/C:/Users/user/proj`
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
 
-                it(`should support Windows paths that contain both backslashes and forward slashes`, () => {
-                    const inputPath = `C:/Users\\user/proj`
-                    const outputPath = `/C:/Users/user/proj`
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
+                    it(`should support Windows paths that contain both backslashes and forward slashes`, () => {
+                        const inputPath = `C:/Users\\user/proj`
+                        const outputPath = `/C:/Users/user/proj`
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
 
-                it(`should support drive: Windows paths`, () => {
-                    const inputPath = `C:`
-                    const outputPath = `/C:`
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
+                    it(`should support drive: Windows paths`, () => {
+                        const inputPath = `C:`
+                        const outputPath = `/C:`
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
 
-                it(`should support UNC Windows paths (\\\\[server]\\[sharename]\\)`, () => {
-                    const inputPath = `\\\\Server01\\user\\docs\\Letter.txt`
-                    const outputPath = `/unc/Server01/user/docs/Letter.txt`
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
+                    it(`should support UNC Windows paths (\\\\[server]\\[sharename]\\)`, () => {
+                        const inputPath = `\\\\Server01\\user\\docs\\Letter.txt`
+                        const outputPath = `/unc/Server01/user/docs/Letter.txt`
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
 
-                it(`should support Long UNC Windows paths (\\\\?\\[server]\\[sharename]\\)`, () => {
-                    const inputPath = `\\\\?\\Server01\\user\\docs\\Letter.txt`
-                    const outputPath = `/unc/?/Server01/user/docs/Letter.txt`
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
+                    it(`should support Long UNC Windows paths (\\\\?\\[server]\\[sharename]\\)`, () => {
+                        const inputPath = `\\\\?\\Server01\\user\\docs\\Letter.txt`
+                        const outputPath = `/unc/?/Server01/user/docs/Letter.txt`
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
 
-                it(`should support Long UNC Windows paths (\\\\?\\UNC\\[server]\\[sharename]\\)`, () => {
-                    const inputPath = `\\\\?\\UNC\\Server01\\user\\docs\\Letter.txt`
-                    const outputPath = `/unc/?/UNC/Server01/user/docs/Letter.txt`
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
+                    it(`should support Long UNC Windows paths (\\\\?\\UNC\\[server]\\[sharename]\\)`, () => {
+                        const inputPath = `\\\\?\\UNC\\Server01\\user\\docs\\Letter.txt`
+                        const outputPath = `/unc/?/UNC/Server01/user/docs/Letter.txt`
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
 
-                it(`should support Long UNC Windows paths (\\\\?\\[drive_spec]:\\)`, () => {
-                    const inputPath = `\\\\?\\C:\\user\\docs\\Letter.txt`
-                    const outputPath = `/unc/?/C:/user/docs/Letter.txt`
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
+                    it(`should support Long UNC Windows paths (\\\\?\\[drive_spec]:\\)`, () => {
+                        const inputPath = `\\\\?\\C:\\user\\docs\\Letter.txt`
+                        const outputPath = `/unc/?/C:/user/docs/Letter.txt`
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
 
-                it(`should support Long UNC Windows paths with dot (\\\\.\\[physical_device]\\)`, () => {
-                    const inputPath = `\\\\.\\PhysicalDevice\\user\\docs\\Letter.txt`
-                    const outputPath = `/unc/.dot/PhysicalDevice/user/docs/Letter.txt`
-                    expect(toPortablePath(inputPath)).to.equal(outputPath)
-                })
-            }
-        })
+                    it(`should support Long UNC Windows paths with dot (\\\\.\\[physical_device]\\)`, () => {
+                        const inputPath = `\\\\.\\PhysicalDevice\\user\\docs\\Letter.txt`
+                        const outputPath = `/unc/.dot/PhysicalDevice/user/docs/Letter.txt`
+                        expect(
+                            withPlatform(platform, () =>
+                                toPortablePath(inputPath),
+                            ),
+                        ).to.equal(outputPath)
+                    })
+                }
+            })
+        }
     })
 })

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -591,3 +591,21 @@ export async function createTypeormMetadataTable(
         true,
     )
 }
+
+export function withPlatform<R>(platform: string, fn: () => R): R {
+    const realPlatform = process.platform
+
+    Object.defineProperty(process, `platform`, {
+        configurable: true,
+        value: platform,
+    })
+
+    const result = fn()
+
+    Object.defineProperty(process, `platform`, {
+        configurable: true,
+        value: realPlatform,
+    })
+
+    return result
+}


### PR DESCRIPTION
Proposed amendment to #11257

Using `beforeEach`/`afterEach` hooks to change the `process.platform` global resulted in unstable behavior in tests. The platform was not being reset to its original 'real' value after the tests were run, causing failures in other subsequent tests.

We can make this cleaner by performing the modification and resetting of `process.platform` synchronously inside each test, ensuring no leakage.